### PR TITLE
Change deployedPairs mapping to use type address

### DIFF
--- a/src/TpdaLiquidationPairFactory.sol
+++ b/src/TpdaLiquidationPairFactory.sol
@@ -35,8 +35,7 @@ contract TpdaLiquidationPairFactory {
     /* ============ Mappings ============ */
 
     /// @notice Mapping to verify if a TpdaLiquidationPair has been deployed via this factory.
-    /// @dev TpdaLiquidationPair address => boolean
-    mapping(TpdaLiquidationPair => bool) public deployedPairs;
+    mapping(address pair => bool wasDeployed) public deployedPairs;
 
     /// @notice Creates a new TpdaLiquidationPair and registers it within the factory
     /// @param _source The liquidation source that the pair will use
@@ -64,7 +63,7 @@ contract TpdaLiquidationPairFactory {
         );
 
         allPairs.push(_liquidationPair);
-        deployedPairs[_liquidationPair] = true;
+        deployedPairs[address(_liquidationPair)] = true;
 
         emit PairCreated(
             _liquidationPair,

--- a/src/TpdaLiquidationRouter.sol
+++ b/src/TpdaLiquidationRouter.sol
@@ -12,7 +12,7 @@ import { TpdaLiquidationPairFactory } from "./TpdaLiquidationPairFactory.sol";
 error UndefinedTpdaLiquidationPairFactory();
 
 /// @notice Throw when the liquidation pair was not created by the liquidation pair factory
-error UnknownTpdaLiquidationPair(TpdaLiquidationPair liquidationPair);
+error UnknownTpdaLiquidationPair(address liquidationPair);
 
 /// @notice Thrown when a swap deadline has passed
 error SwapExpired(uint256 deadline);
@@ -81,7 +81,7 @@ contract TpdaLiquidationRouter is IFlashSwapCallback {
         uint256 _amountOut,
         uint256 _amountInMax,
         uint256 _deadline
-    ) external onlyTrustedTpdaLiquidationPair(_liquidationPair) returns (uint256) {
+    ) external onlyTrustedTpdaLiquidationPair(address(_liquidationPair)) returns (uint256) {
         if (block.timestamp > _deadline) {
             revert SwapExpired(_deadline);
         }
@@ -114,7 +114,7 @@ contract TpdaLiquidationRouter is IFlashSwapCallback {
         uint256 _amountIn,
         uint256,
         bytes calldata _flashSwapData
-    ) external override onlyTrustedTpdaLiquidationPair(TpdaLiquidationPair(msg.sender)) onlySelf(_sender) {
+    ) external override onlyTrustedTpdaLiquidationPair(msg.sender) onlySelf(_sender) {
         address _originalSender = abi.decode(_flashSwapData, (address));
         IERC20(TpdaLiquidationPair(msg.sender).tokenIn()).safeTransferFrom(
             _originalSender,
@@ -124,8 +124,8 @@ contract TpdaLiquidationRouter is IFlashSwapCallback {
     }
 
     /// @notice Checks that the given pair was created by the factory
-    /// @param _liquidationPair The pair to check
-    modifier onlyTrustedTpdaLiquidationPair(TpdaLiquidationPair _liquidationPair) {
+    /// @param _liquidationPair The pair address to check
+    modifier onlyTrustedTpdaLiquidationPair(address _liquidationPair) {
         if (!_liquidationPairFactory.deployedPairs(_liquidationPair)) {
             revert UnknownTpdaLiquidationPair(_liquidationPair);
         }

--- a/test/TpdaLiquidationPairFactory.t.sol
+++ b/test/TpdaLiquidationPairFactory.t.sol
@@ -74,7 +74,7 @@ contract TpdaLiquidationPairFactoryTest is Test {
     assertEq(factory.totalPairs(), 1, "one pair exists");
     assertEq(address(factory.allPairs(0)), address(lp), "pair is in array");
 
-    assertTrue(factory.deployedPairs(lp));
+    assertTrue(factory.deployedPairs(address(lp)));
 
     assertEq(address(lp.source()), source);
     assertEq(address(lp.tokenIn()), tokenIn);

--- a/test/TpdaLiquidationRouter.t.sol
+++ b/test/TpdaLiquidationRouter.t.sol
@@ -61,7 +61,7 @@ contract TpdaLiquidationRouterTest is Test {
     );
     vm.mockCall(
       address(factory),
-      abi.encodeCall(factory.deployedPairs, liquidationPair),
+      abi.encodeCall(factory.deployedPairs, address(liquidationPair)),
       abi.encode(true)
     );
 
@@ -129,7 +129,7 @@ contract TpdaLiquidationRouterTest is Test {
   function testFlashSwapCallback_UnknownLiquidationPair() public {
     vm.mockCall(
       address(factory),
-      abi.encodeCall(factory.deployedPairs, TpdaLiquidationPair(address(this))),
+      abi.encodeCall(factory.deployedPairs, address(this)),
       abi.encode(false)
     );
     vm.expectRevert(abi.encodeWithSelector(UnknownTpdaLiquidationPair.selector, address(this)));
@@ -156,7 +156,7 @@ contract TpdaLiquidationRouterTest is Test {
   function testSwapExactAmountOut_UnknownLiquidationPair() public {
     vm.mockCall(
       address(factory),
-      abi.encodeCall(factory.deployedPairs, liquidationPair),
+      abi.encodeCall(factory.deployedPairs, address(liquidationPair)),
       abi.encode(false)
     );
     vm.expectRevert(abi.encodeWithSelector(UnknownTpdaLiquidationPair.selector, liquidationPair));


### PR DESCRIPTION
Callers are checking `deployedPairs` since they may not know if the address they are checking is a `TpdaLiquidationPair` and want to verify that it is. As such, the mapping should accept an address type instead of a `TpdaLiquidationPair` type.